### PR TITLE
Add imagemagick and ffmpeg to damsrepo container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV DAMS_USER dams
 ENV DAMS_PASS dams
 
 # Install dockerize for postgres dependency
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl imagemagick ffmpeg
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
I noticed some errors popup in the test suite runs related to damsrepo not having ffmpeg or imagemagick available. somehow though, the tests still pass. in any event, including these packages seems like a more 'correct' thing to do. 

@lsitu - What are your thoughts? Locally, using this tagged version passes all tests for me using the /dev/docker-compose.yml setup.