### PR TITLE
Add FITS to damsrepo dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM openjdk:8-alpine as damsrepo-builder
 MAINTAINER "Matt Critchlow <mcritchlow@ucsd.edu">
 
-RUN apk add --no-cache apache-ant git
+RUN apk add --no-cache apache-ant git unzip
 RUN git clone https://github.com/ucsdlib/damsrepo.git /tmp/damsrepo
 WORKDIR /tmp/damsrepo
 RUN ant webapp
@@ -11,6 +11,19 @@ RUN mkdir -p /pub/dams
 RUN mv /tmp/damsrepo/dist/dams.war /pub/dams/
 RUN mv /tmp/damsrepo/src/properties/jhove.conf /pub/dams/
 RUN mv /tmp/damsrepo/src/lib2/postgresql-9.2-1002.jdbc4.jar /pub/dams/
+
+# Get fits
+ENV FITS_VERSION 1.3.0
+RUN wget https://projects.iq.harvard.edu/files/fits/files/fits-$FITS_VERSION.zip \
+    && unzip fits-$FITS_VERSION.zip -d /usr/local/bin/fits \
+    && chmod 0755 /usr/local/bin/fits/fits.sh \
+    && rm fits-$FITS_VERSION.zip
+
+# Get dockerize
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 FROM tomcat:7-jre8-alpine
 MAINTAINER "Matt Critchlow <mcritchlow@ucsd.edu">
@@ -21,14 +34,12 @@ ENV MANAGER_PASS tomcat
 ENV DAMS_USER dams
 ENV DAMS_PASS dams
 
-# Install dockerize for postgres dependency
 RUN apk add --no-cache openssl imagemagick ffmpeg
 
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
+# install dockerize
+COPY --from=damsrepo-builder /usr/local/bin/dockerize /usr/local/bin/dockerize
+# install fits
+COPY --from=damsrepo-builder /usr/local/bin/fits /usr/local/bin/fits
 
 # setup config and other required files
 COPY tomcat/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml

--- a/damsrepo/dams.properties
+++ b/damsrepo/dams.properties
@@ -4,6 +4,11 @@ format.default = xml
 # editor backup save dir
 edit.backupDir = /pub/dams/editBackups
 
+# path to the FITS configuration file. The file fits.xml provided in source code will be used by default
+# characterization.fits.config = /pub/data2/dams/fits.xml
+# path to the FITS installation
+characterization.fits.command = /usr/local/bin/fits/fits.sh
+
 # derivatives and characterization
 derivatives.list = 2,3,4,5,6,7
 derivatives.ext = .jpg


### PR DESCRIPTION
Changes:
  - install FITS 1.3.0
  - move Dockerize install to builder image to use multi-stage build
pattern more efficiently
  - Set command path to `/usr/local/bin/fits/fits.sh`